### PR TITLE
fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PROJECT = xdp_acl
 .PHONY: clean $(PROJECT) pub
 
 
-all: xdp_acl.c main.go
+all: main.go
 	@go generate && go build
 
 clean:


### PR DESCRIPTION
fix 

> make: *** No rule to make target 'xdp_acl.c', needed by 'all'.  Stop.